### PR TITLE
Fix Social API Service

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -157,7 +157,7 @@
 				    "iconURL":   "https://sharetodiaspora.github.io/assets/diaspora-icon-16.png",
 				    "icon32URL": "https://sharetodiaspora.github.io/assets/diaspora-icon-32.png",
 				    "icon64URL": "https://sharetodiaspora.github.io/assets/diaspora-icon-64.png",
-				    "shareURL": "http://sharetodiaspora.github.io/?url=%{url}&title=%{title}&notes=%{text}",
+				    "shareURL": "https://sharetodiaspora.github.io/?url=%{url}&title=%{title}&notes=%{text}",
 				    "version": "1.0.0"
 				  };
 				  function activateSocialFeature(node) {


### PR DESCRIPTION
Recent versions of Firefox require the Social API Share Service to use https (or the Share service stops working with a "Firefox could not connect to Diaspora" error. Do so.