### PR TITLE
Use https for redirecting to pods (if requested)

### DIFF
--- a/js/share.js
+++ b/js/share.js
@@ -337,7 +337,7 @@ var Redirection = (function() {
           ("[" + Parameters.title + "]" + "(" + Parameters.url + ")") :
           Parameters.title;
 
-      var bookmarklet = "http://" + pod + "/bookmarklet?title=" +
+      var bookmarklet = location.protocol + "//" + pod + "/bookmarklet?title=" +
         encodeURIComponent(title) +
         "&url=" + encodeURIComponent(url) +
         (Parameters.notes.length > 0 ? ("&notes=" + Parameters.notes) : "") +


### PR DESCRIPTION
If sharetodiaspora.github.io was reach using HTTPS, also use HTTPS to redirect to the pod.

This is also necessary to fully fix the Firefox Social Service API (which, it seems, requires HTTPS for the initial URL, but also for the redirections).