### PR TITLE
replace + signs before decoding

### DIFF
--- a/js/share.js
+++ b/js/share.js
@@ -13,7 +13,7 @@ var Parameters = (function() {
     if (results == null)
       return "";
     else
-      return decodeURIComponent(results[1]);
+      return decodeURIComponent(results[1].replace(/\+/g, '%20'));
   }
 
   return {


### PR DESCRIPTION
Sometimes URI components contain `+` signs as a indicator for spaces. The JavaScript function decodeURIComponent doesn't seem to replace them.

So this change will replace unencoded + signs before decoding it. Is there a edge case where this could cause unwanted behaviour?